### PR TITLE
Allow "image/" prefix on data URIs

### DIFF
--- a/src/lexer.pest
+++ b/src/lexer.pest
@@ -55,4 +55,4 @@ table_start = { "|"? ~ table_marker ~ ("|" ~ table_marker)* ~ "|"? ~ table_space
 table_cell_end = { "|" ~ table_spacechar* ~ table_newline? }
 table_row_end = { table_spacechar* ~ table_newline }
 
-dangerous_url = { "data:" ~ !("png" | "gif" | "jpeg" | "webp") | "javascript:" | "vbscript:" | "file:" }
+dangerous_url = { "data:" ~ "image/"? ~ !("png" | "gif" | "jpeg" | "webp") | "javascript:" | "vbscript:" | "file:" }


### PR DESCRIPTION
Update the `dangerous_url` grammar rule to allow URIs that begin with `data:image/`, followed by a valid media type. This is an optional modifier and does not affect URIs that do not contain this prefix.

I'd like to add this because this is the default behavior of [Toast UI's Editor](https://ui.toast.com/tui-editor/) when adding images and outputting Markdown code.

According to [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs), Data URIs consist of the following format:

```
data:[<mediatype>][;base64],<data>
```

This documentation then states:

> The mediatype is a MIME type string, such as 'image/jpeg' for a JPEG image file.